### PR TITLE
Add Developer Certificate of Origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,37 @@
 A fedimint wallet in Dart + Rust.
 
 ![Frame 67 (2)](https://user-images.githubusercontent.com/543668/172901667-df3eb020-db13-40b1-8aa5-8041a9782e5a.png)
+
+# Contributing
+
+Contributions are very welcome, just open an issue or PR if you see something to improve!
+
+Please note that all contributions happen under the MIT license as described below:
+
+```
+Developer Certificate of Origin
+Version 1.1
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+Developer's Certificate of Origin 1.1
+By making a contribution to this project, I certify that:
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```


### PR DESCRIPTION
I was advised to add a statement that all contributions happen under the same license as the project is licensed under. I think that's common sense anyway, but lawyers might disagree, like so often. I think this change doesn't hurt anyone so I'd just go for it.

Could all contributors so far please indicate their acceptance of these terms in a comment below? I'm sorry, it's a bit silly, but might save us a lot of trouble later. Pinging @Maan2003 @futurepaul.